### PR TITLE
remove obsolete orientation flipping from example code

### DIFF
--- a/example/src/app/home/home.page.ts
+++ b/example/src/app/home/home.page.ts
@@ -135,15 +135,6 @@ export class HomePage implements OnInit, OnDestroy {
       // lock screen orientation when recording
       const orientation = await ScreenOrientation.orientation();
 
-      if (this.platform.is('ios')) {
-        // On iOS the landscape-primary and landscape-secondary are flipped for some reason
-        if (orientation.type === 'landscape-primary') {
-          orientation.type = 'landscape-secondary'
-        } else if (orientation.type === 'landscape-secondary') {
-          orientation.type = 'landscape-primary'
-        }
-      }
-
       await ScreenOrientation.lock({ orientation: orientation.type });
 
       this.durationIntervalId = setInterval(() => {


### PR DESCRIPTION
Remove obsolete orientation-flipping on iOS. No longer needed.