### PR TITLE
fix(ios): don't disable flash on initialize

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -220,9 +220,6 @@ public class VideoRecorder: CAPPlugin, AVCaptureFileOutputRecordingDelegate {
         // log to console for initializing
         print("Initializing camera")
 
-        // flash is turned off by default when initializing camera
-        self._isFlashEnabled = false;
-
         if (self.captureSession?.isRunning != true) {
             self.currentCamera = call.getInt("camera", 0)
             self.quality = call.getInt("quality", 0)


### PR DESCRIPTION
I think it closes https://github.com/capacitor-community/video-recorder/issues/30

While setting the flash to false on initialize was done on purpose to match Android behavior, I don't think it's the ideal behavior.

If running the example app, you record a video with the flash on, stop it, it shows the list of videos and the flash button as on.
Then you click the camera button, which calls initialize and starts the recording, it will start recording with the flash off as initialize sets it to false.

I think it would be preferred to remember the last setting instead of setting it to false on every initialize.

Can be considered a breaking change, so maybe not merge until next major version.

Or disregard if you thing setting it to false is the correct behavior, but then the example app should be updated as it's a bit confusing.