### PR TITLE
fix(example): Make background transparent for dark mode

### DIFF
--- a/example/src/theme/variables.scss
+++ b/example/src/theme/variables.scss
@@ -1,2 +1,9 @@
 // For information on how to create your own theme, please see:
 // http://ionicframework.com/docs/theming/
+@import "@ionic/angular/css/palettes/dark.system.css";
+
+@media (prefers-color-scheme: dark) {
+  :root.ios {
+    --ion-background-color: transparent;
+  }
+}


### PR DESCRIPTION
closes https://github.com/capacitor-community/video-recorder/issues/24

might not be ideal as it might cause other issue making the whole app background transparent

alternatively, it could get the current background, then call `document.body.style.background = 'transparent';` from javascript when the camera view gets initialized and restore the original background color on camera view destroy